### PR TITLE
Allow reusing a custom_script_path directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ that performs the extension installing, and the error behavior.
 
   Filesystem path where to look for *custom scripts*.
 
+* `extwlist.extname_from_filename`
+
+  When this flag is set to true, custom_path is interpreted as the only directory
+  to look for all custom scripts; the first part of the custom script is interpreted
+  as the target extension name.
+
 ## Usage
 
 That's quite simple:
@@ -186,6 +192,19 @@ Similarly:
    - `${extwlist.custom_path}/extname/after-drop.sql`
 
 Version-specific hook files are not supported here.
+
+When `extwlist.extname_from_filename` is set, a names of the `extname`
+custom scripts shall look like this:
+
+   - `${extwlist.custom_path}/extname--before-create.sql`
+   - `${extwlist.custom_path}/extname--after-create.sql`
+
+   - `${extwlist.custom_path}/extname--before-update.sql`
+   - `${extwlist.custom_path}/extname--after-update.sql`
+
+Both simple and version-specific hooks are supported:
+
+   - `${extwlist.custom_path}/extname--before--1.0--1.1.sql`
 
 #### custom scripts templating
 

--- a/expected/pgextwlist.out
+++ b/expected/pgextwlist.out
@@ -66,3 +66,37 @@ SELECT groname FROM pg_group WHERE groname = 'stat_resetters';
 ---------
 (0 rows)
 
+-- whitelisted extension with extension name extracted from the custom script filename
+SELECT set_extwlist_extname_from_filename();
+ set_extwlist_extname_from_filename 
+------------------------------------
+ 
+(1 row)
+
+CREATE EXTENSION pg_stat_statements;
+SELECT extname FROM pg_extension ORDER BY 1;
+      extname       
+--------------------
+ citext
+ pg_stat_statements
+ plpgsql
+(3 rows)
+
+SELECT proacl FROM pg_proc WHERE proname = 'pg_stat_statements_reset';
+                          proacl                           
+-----------------------------------------------------------
+ {mere_mortal=X/mere_mortal,stat_resetters2=X/mere_mortal}
+(1 row)
+
+SELECT groname FROM pg_group WHERE groname = 'stat_resetters2';
+     groname     
+-----------------
+ stat_resetters2
+(1 row)
+
+DROP EXTENSION pg_stat_statements;
+SELECT groname FROM pg_group WHERE groname = 'stat_resetters2';
+ groname 
+---------
+(0 rows)
+

--- a/expected/setup.out
+++ b/expected/setup.out
@@ -10,3 +10,6 @@ SELECT pg_reload_conf();
 (1 row)
 
 CREATE ROLE mere_mortal;
+CREATE OR REPLACE FUNCTION set_extwlist_extname_from_filename() RETURNS VOID SECURITY DEFINER AS $$
+    SET extwlist.extname_from_filename TO true;
+$$ LANGUAGE SQL;

--- a/pgextwlist.c
+++ b/pgextwlist.c
@@ -63,6 +63,7 @@ PG_MODULE_MAGIC;
 
 char *extwlist_extensions = NULL;
 char *extwlist_custom_path = NULL;
+bool extwlist_extname_from_filename = false;
 
 static ProcessUtility_hook_type prev_ProcessUtility = NULL;
 
@@ -173,7 +174,18 @@ _PG_init(void)
 							   NULL,
 							   NULL);
 
-	EmitWarningsOnPlaceholders("extwlist");
+    DefineCustomBoolVariable("extwlist.extname_from_filename",
+                               "Flag allowing a lookup of extension name in custom script filename",
+                               "",
+                               &extwlist_extname_from_filename,
+                               false,
+                               PGC_SUSET,
+                               GUC_NOT_IN_SAMPLE,
+                               NULL,
+                               NULL,
+                               NULL);
+
+    EmitWarningsOnPlaceholders("extwlist");
 
 	prev_ProcessUtility = ProcessUtility_hook;
 	ProcessUtility_hook = extwlist_ProcessUtility;
@@ -192,6 +204,13 @@ _PG_init(void)
  *
  * - action is expected to be one of "create", "update", "comment", or "drop"
  * - when   is expected to be either "before" or "after"
+ *
+ * if extwlist.extname_from_filename is set, then custom scripts must have the following format:
+ *
+ *  ${extwlist_custom_path}/${extname}--${when}--${version}.sql (create)
+ *  ${extwlist_custom_path}/${extname}--${when}--${oldversion}--${newversion}.sql (upgrade)
+ *  ${extwlist_custom_path}/${extname}--${when}-${action}--${version}.sql (rest)
+ *  ${extwlist_custom_path}/${extname}--${when}-${action}.sql (all actions)
  *
  * We don't validation the extension's name before building the scripts path
  * here because the extension name we are dealing with must have already been

--- a/sql/pgextwlist.sql
+++ b/sql/pgextwlist.sql
@@ -22,3 +22,13 @@ SELECT proacl FROM pg_proc WHERE proname = 'pg_stat_statements_reset';
 SELECT groname FROM pg_group WHERE groname = 'stat_resetters';
 DROP EXTENSION pg_stat_statements;
 SELECT groname FROM pg_group WHERE groname = 'stat_resetters';
+
+-- whitelisted extension with extension name extracted from the custom script filename
+SELECT set_extwlist_extname_from_filename();
+
+CREATE EXTENSION pg_stat_statements;
+SELECT extname FROM pg_extension ORDER BY 1;
+SELECT proacl FROM pg_proc WHERE proname = 'pg_stat_statements_reset';
+SELECT groname FROM pg_group WHERE groname = 'stat_resetters2';
+DROP EXTENSION pg_stat_statements;
+SELECT groname FROM pg_group WHERE groname = 'stat_resetters2';

--- a/sql/setup.sql
+++ b/sql/setup.sql
@@ -6,3 +6,7 @@ ALTER SYSTEM SET extwlist.custom_path=:'testdir';
 SELECT pg_reload_conf();
 
 CREATE ROLE mere_mortal;
+
+CREATE OR REPLACE FUNCTION set_extwlist_extname_from_filename() RETURNS VOID SECURITY DEFINER AS $$
+    SET extwlist.extname_from_filename TO true;
+$$ LANGUAGE SQL;

--- a/test-scripts/pg_stat_statements--after-create.sql
+++ b/test-scripts/pg_stat_statements--after-create.sql
@@ -1,0 +1,3 @@
+ALTER FUNCTION pg_stat_statements_reset OWNER TO mere_mortal;
+CREATE ROLE stat_resetters2;
+GRANT EXECUTE ON FUNCTION pg_stat_statements_reset TO stat_resetters2;

--- a/test-scripts/pg_stat_statements--after-drop.sql
+++ b/test-scripts/pg_stat_statements--after-drop.sql
@@ -1,0 +1,1 @@
+DROP ROLE stat_resetters2;

--- a/utils.c
+++ b/utils.c
@@ -131,6 +131,11 @@ parse_default_version_in_control_file(const char *extname,
  *  ${extwlist_custom_path}/${extname}/${when}--${version}.sql (upgrade)
  *  ${extwlist_custom_path}/${extname}/${when}-${action}.sql (create)
  *  ${extwlist_custom_path}/${extname}/${when}-${action}--${version}.sql (rest)
+ *
+ *  if extwlist.extname_from_file is set, the following format is used instead:
+ *  ${extwlist_custom_path}/${extname}--${when}--${version}.sql (upgrade)
+ *  ${extwlist_custom_path}/${extname}--${when}-${action}.sql (create)
+ *  ${extwlist_custom_path}/${extname}--${when}-${action}--${version}.sql (rest)
  */
 char *
 get_generic_custom_script_filename(const char *name,
@@ -143,8 +148,13 @@ get_generic_custom_script_filename(const char *name,
 		return NULL;
 
 	result = (char *) palloc(MAXPGPATH);
-	snprintf(result, MAXPGPATH, "%s/%s/%s-%s.sql",
-			 extwlist_custom_path, name, when, action);
+    if (extwlist_extname_from_filename) {
+        snprintf(result, MAXPGPATH, "%s/%s--%s-%s.sql",
+                 extwlist_custom_path, name, when, action);
+    } else{
+        snprintf(result, MAXPGPATH, "%s/%s/%s-%s.sql",
+                 extwlist_custom_path, name, when, action);
+    }
 
 	return result;
 }
@@ -161,12 +171,24 @@ get_specific_custom_script_filename(const char *name,
 		return NULL;
 
 	result = (char *) palloc(MAXPGPATH);
-	if (from_version)
-		snprintf(result, MAXPGPATH, "%s/%s/%s--%s--%s.sql",
-				 extwlist_custom_path, name, when, from_version, version);
-	else
-		snprintf(result, MAXPGPATH, "%s/%s/%s--%s.sql",
-				 extwlist_custom_path, name, when, version);
+	if (from_version) {
+        if (extwlist_extname_from_filename) {
+            snprintf(result, MAXPGPATH, "%s/%s--%s--%s--%s.sql",
+                     extwlist_custom_path, name, when, from_version, version);
+        } else {
+            snprintf(result, MAXPGPATH, "%s/%s/%s--%s--%s.sql",
+                     extwlist_custom_path, name, when, from_version, version);
+        }
+    }
+	else {
+        if (extwlist_extname_from_filename) {
+            snprintf(result, MAXPGPATH, "%s/%s--%s--%s.sql",
+                     extwlist_custom_path, name, when, version);
+        } else {
+            snprintf(result, MAXPGPATH, "%s/%s/%s--%s.sql",
+                     extwlist_custom_path, name, when, version);
+        }
+    }
 
 	return result;
 }

--- a/utils.h
+++ b/utils.h
@@ -18,6 +18,7 @@
 
 extern char *extwlist_extensions;
 extern char *extwlist_custom_path;
+extern bool extwlist_extname_from_filename;
 
 char *get_specific_custom_script_filename(const char *name,
 										  const char *when,


### PR DESCRIPTION
Introduce a new option, extwlist.extname_from_filename, which uses first part of the custom script filename instead of the subdirectory of custom_script_path to indicate the extension.

This simplifies adding custom scripts for multiple extensions without producing subdirectories, i.e. when mounting a configmap in Kubernetes.