### PR TITLE
Replace @new_version@ in custom scripts with the target version.

### DIFF
--- a/pgextwlist.c
+++ b/pgextwlist.c
@@ -237,7 +237,7 @@ call_extension_scripts(const char *extname,
 
 		if (access(specific_custom_script, F_OK) == 0)
 		{
-			execute_custom_script(specific_custom_script, schema);
+            execute_custom_script(specific_custom_script, schema, version);
 			return; /* skip generic script */
 		}
 	}
@@ -248,7 +248,7 @@ call_extension_scripts(const char *extname,
 	elog(DEBUG1, "Considering custom script \"%s\"", generic_custom_script);
 
 	if (access(generic_custom_script, F_OK) == 0)
-		execute_custom_script(generic_custom_script, schema);
+        execute_custom_script(generic_custom_script, schema, version);
 }
 
 static bool

--- a/utils.c
+++ b/utils.c
@@ -564,7 +564,7 @@ get_current_database_owner_name()
  * Execute given script
  */
 void
-execute_custom_script(const char *filename, const char *schemaName)
+execute_custom_script(const char *filename, const char *schemaName, const char *version)
 {
 	int			save_nestlevel;
 	StringInfoData pathbuf;
@@ -682,6 +682,17 @@ execute_custom_script(const char *filename, const char *schemaName)
 									CStringGetTextDatum("@database_owner@"),
 									CStringGetTextDatum(
 										get_current_database_owner_name()));
+
+        /*
+         * substitute the target version for the occurrences of @new_version@
+         */
+        if (version != NULL && strlen(version) > 0) {
+            t_sql = DirectFunctionCall3Coll(replace_text,
+                                            C_COLLATION_OID,
+                                            t_sql,
+                                            CStringGetTextDatum("@new_version@"),
+                                            CStringGetTextDatum(version));
+        }
 
 		/* And now back to C string */
 		c_sql = text_to_cstring(DatumGetTextPP(t_sql));

--- a/utils.h
+++ b/utils.h
@@ -37,6 +37,6 @@ void fill_in_extension_properties(const char *extname,
 								  char **old_version,
 								  char **new_version);
 
-void execute_custom_script(const char *schemaName, const char *filename);
+void execute_custom_script(const char *schemaName, const char *filename, const char *version);
 
 #endif


### PR DESCRIPTION
Instead of creating one script per version pair for updates, define a single script, which can act on @new_version@ value.

The main purpose is to prevent updates to the given version without introducing new scripts.