### PR TITLE
Add safe environment check for pg_temp objects before CREATE EXTENSION

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ OBJS       = utils.o pgextwlist.o
 DOCS       = README.md
 REGRESS    = setup pgextwlist errors crossuser hooks
 REGRESS_OPTS += --temp-instance=./tmp_check --temp-config=test.conf
+REGRESS    = setup pgextwlist errors crossuser hooks pg_temp
 RPM_MINOR_VERSION_SUFFIX ?=
 
 PG_CONFIG = pg_config

--- a/expected/pg_temp.out
+++ b/expected/pg_temp.out
@@ -1,0 +1,33 @@
+SET ROLE admin;
+-- verify baseline: whitelisted extension can be created normally
+CREATE EXTENSION citext;
+SELECT extname FROM pg_extension WHERE extname = 'citext';
+ extname 
+---------
+ citext
+(1 row)
+
+DROP EXTENSION citext;
+-- create a temporary table to populate pg_temp
+CREATE TEMP TABLE pg_proc AS SELECT * FROM pg_catalog.pg_proc;
+-- whitelisted extension should be blocked when pg_temp is not empty
+CREATE EXTENSION citext;
+ERROR:  extension "citext" cannot be installed with temporary objects in the session
+HINT:  Start a new session and execute CREATE EXTENSION as the first command. Make sure to pass the "-X" flag to psql.
+SELECT extname FROM pg_extension WHERE extname = 'citext';
+ extname 
+---------
+(0 rows)
+
+-- clean up temp table
+DROP TABLE pg_temp.pg_proc;
+-- now with pg_temp empty, creation should succeed again
+CREATE EXTENSION citext;
+SELECT extname FROM pg_extension WHERE extname = 'citext';
+ extname 
+---------
+ citext
+(1 row)
+
+-- clean up
+DROP EXTENSION citext;

--- a/expected/setup.out
+++ b/expected/setup.out
@@ -6,7 +6,9 @@ SELECT pg_reload_conf();
  t
 (1 row)
 
+CREATE ROLE admin;
 CREATE ROLE mere_mortal;
+GRANT CREATE ON DATABASE contrib_regression TO admin;
 CREATE OR REPLACE FUNCTION set_extwlist_extname_from_filename() RETURNS VOID SECURITY DEFINER AS $$
     SET extwlist.extname_from_filename TO true;
 $$ LANGUAGE SQL;

--- a/pgextwlist.c
+++ b/pgextwlist.c
@@ -21,6 +21,7 @@
 #include "catalog/dependency.h"
 #include "catalog/indexing.h"
 #include "catalog/objectaccess.h"
+#include "catalog/pg_class.h"
 #include "catalog/pg_auth_members.h"
 #include "catalog/pg_authid.h"
 #include "catalog/pg_database.h"
@@ -51,6 +52,12 @@
 #endif
 #if PG_MAJOR_VERSION >= 1000
 #include "utils/varlena.h"
+#endif
+#if PG_MAJOR_VERSION >= 1200
+#include "access/table.h"
+#else
+#define table_open(r, l) heap_open(r, l)
+#define table_close(r, l) heap_close(r, l)
 #endif
 
 /*
@@ -251,6 +258,50 @@ call_extension_scripts(const char *extname,
 		execute_custom_script(generic_custom_script, schema);
 }
 
+/*
+ * We do not allow extensions to be created or updated if there are temporary
+ * objects in the session, because those objects could shadow objects accessed
+ * by the extension's script, leading to security vulnerabilities for extensions
+ * that do not schema-qualify their objects or lock down their search_path.
+ */
+static void
+pg_temp_is_empty(const char *name)
+{
+	Oid			temp_namespace;
+	Relation	rel;
+	ScanKeyData key[1];
+	SysScanDesc scan;
+
+	temp_namespace = LookupExplicitNamespace("pg_temp", true);
+	if (!OidIsValid(temp_namespace))
+		return;
+
+	rel = table_open(RelationRelationId, AccessShareLock);
+
+	ScanKeyInit(&key[0],
+				Anum_pg_class_relnamespace,
+				BTEqualStrategyNumber, F_OIDEQ,
+				ObjectIdGetDatum(temp_namespace));
+
+	scan = systable_beginscan(rel, InvalidOid, false,
+							  NULL, 1, key);
+
+	if (HeapTupleIsValid(systable_getnext(scan)))
+		ereport(ERROR, (errcode(ERRCODE_OPERATOR_INTERVENTION),
+			errmsg("extension \"%s\" cannot be installed with temporary objects in the session", name),
+			errhint("Start a new session and execute CREATE EXTENSION as the first command. "
+				"Make sure to pass the \"-X\" flag to psql.")));
+
+	systable_endscan(scan);
+	table_close(rel, AccessShareLock);
+}
+
+static void
+check_environment(const char *name)
+{
+	pg_temp_is_empty(name);
+}
+
 static bool
 extension_is_whitelisted(const char *name)
 {
@@ -315,6 +366,7 @@ extwlist_ProcessUtility(PROCESS_UTILITY_PROTO_ARGS)
 
 			if (extension_is_whitelisted(name))
 			{
+        check_environment(name);
 				call_ProcessUtility(PROCESS_UTILITY_ARGS,
 									name, schema,
 									old_version, new_version, "create");

--- a/sql/pg_temp.sql
+++ b/sql/pg_temp.sql
@@ -1,0 +1,24 @@
+
+SET ROLE admin;
+
+-- verify baseline: whitelisted extension can be created normally
+CREATE EXTENSION citext;
+SELECT extname FROM pg_extension WHERE extname = 'citext';
+DROP EXTENSION citext;
+
+-- create a temporary table to populate pg_temp
+CREATE TEMP TABLE pg_proc AS SELECT * FROM pg_catalog.pg_proc;
+
+-- whitelisted extension should be blocked when pg_temp is not empty
+CREATE EXTENSION citext;
+SELECT extname FROM pg_extension WHERE extname = 'citext';
+
+-- clean up temp table
+DROP TABLE pg_temp.pg_proc;
+
+-- now with pg_temp empty, creation should succeed again
+CREATE EXTENSION citext;
+SELECT extname FROM pg_extension WHERE extname = 'citext';
+
+-- clean up
+DROP EXTENSION citext;

--- a/sql/setup.sql
+++ b/sql/setup.sql
@@ -2,7 +2,10 @@
 ALTER SYSTEM SET extwlist.custom_path=:'testdir';
 SELECT pg_reload_conf();
 
+CREATE ROLE admin;
 CREATE ROLE mere_mortal;
+
+GRANT CREATE ON DATABASE contrib_regression TO admin;
 
 CREATE OR REPLACE FUNCTION set_extwlist_extname_from_filename() RETURNS VOID SECURITY DEFINER AS $$
     SET extwlist.extname_from_filename TO true;


### PR DESCRIPTION
Refuse to grant whitelisted extension creation privileges when temporary
objects exist in the session's pg_temp schema, as they could be used to
hijack the extension installation process.
