### PR TITLE
Use temporary cluster for installcheck via pg_regress --temp-instance

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -1,9 +1,13 @@
 name: make installcheck
-on: [push, pull_request]
+on:
+  push:
+    branches: [master]
+  pull_request:
 
 jobs:
   test:
     strategy:
+      fail-fast: false
       matrix:
         pg:
           - 18
@@ -28,4 +32,8 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Test on PostgreSQL ${{ matrix.pg }}
-        run: pg-build-test
+        run: |
+          sudo make install
+          chown -R postgres:postgres .
+          sudo -u postgres make installcheck
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
 *.o
-pgextwlist.so
 .deps
 .vagrant
+pgextwlist.so
+regression.diffs
+regression.out
+results
+tmp_check

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ MODULE_big = pgextwlist
 OBJS       = utils.o pgextwlist.o
 DOCS       = README.md
 REGRESS    = setup pgextwlist errors crossuser hooks
+REGRESS_OPTS += --temp-instance=./tmp_check --temp-config=test.conf
 RPM_MINOR_VERSION_SUFFIX ?=
 
 PG_CONFIG = pg_config

--- a/expected/setup.out
+++ b/expected/setup.out
@@ -1,6 +1,3 @@
-LOAD 'pgextwlist';
-ALTER SYSTEM SET session_preload_libraries='pgextwlist';
-ALTER SYSTEM SET extwlist.extensions='citext,earthdistance,pg_trgm,pg_stat_statements,refint';
 \set testdir `pwd` '/test-scripts'
 ALTER SYSTEM SET extwlist.custom_path=:'testdir';
 SELECT pg_reload_conf();

--- a/sql/setup.sql
+++ b/sql/setup.sql
@@ -1,6 +1,3 @@
-LOAD 'pgextwlist';
-ALTER SYSTEM SET session_preload_libraries='pgextwlist';
-ALTER SYSTEM SET extwlist.extensions='citext,earthdistance,pg_trgm,pg_stat_statements,refint';
 \set testdir `pwd` '/test-scripts'
 ALTER SYSTEM SET extwlist.custom_path=:'testdir';
 SELECT pg_reload_conf();

--- a/test.conf
+++ b/test.conf
@@ -1,0 +1,2 @@
+session_preload_libraries = 'pgextwlist'
+extwlist.extensions = 'citext,earthdistance,pg_trgm,pg_stat_statements,refint'


### PR DESCRIPTION
Instead of requiring a running PostgreSQL cluster, installcheck now
creates a temporary instance automatically. Server configuration
(session_preload_libraries, extwlist.extensions) moves to test.conf.
