### PR TITLE
Restrict function shadow check to variadic functions for timescaledb

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -34,6 +34,7 @@ jobs:
       - name: Test on PostgreSQL ${{ matrix.pg }}
         run: |
           sudo make install
+          sudo make install-tsdb-stub
           chown -R postgres:postgres .
           sudo -u postgres make installcheck
 

--- a/Makefile
+++ b/Makefile
@@ -4,13 +4,42 @@ long_ver = $(shell (git describe --tags --long '--match=v*' 2>/dev/null || echo 
 MODULE_big = pgextwlist
 OBJS       = utils.o pgextwlist.o
 DOCS       = README.md
-REGRESS    = setup pgextwlist errors crossuser hooks pg_temp catalog_shadow
+REGRESS    = setup pgextwlist errors crossuser hooks pg_temp catalog_shadow variadic_shadow
 REGRESS_OPTS += --temp-instance=./tmp_check --temp-config=test.conf
 RPM_MINOR_VERSION_SUFFIX ?=
 
 PG_CONFIG = pg_config
 PGXS = $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
+
+# Stub "timescaledb" extension used by the variadic_shadow regression test
+# to exercise the timescaledb-only branch of the function-shadow check
+# without depending on a real TimescaleDB install. Writes to the host
+# sharedir, so this target must be run with the same privileges as
+# `make install`.
+#
+# If a real TimescaleDB is installed, we keep its control file and only
+# add our --0.0.0.sql alongside its many version files. The regression
+# test uses CREATE EXTENSION timescaledb VERSION '0.0.0' so the real
+# .so is never loaded and the preload check is skipped.
+EXT_DIR := $(shell $(PG_CONFIG) --sharedir)/extension
+
+.PHONY: install-tsdb-stub uninstall-tsdb-stub
+install-tsdb-stub:
+	@if [ -e "$(EXT_DIR)/timescaledb.control" ] && \
+	    ! grep -q "pgextwlist test stub" "$(EXT_DIR)/timescaledb.control"; then \
+	  echo "real timescaledb at $(EXT_DIR), keeping its control file"; \
+	else \
+	  $(INSTALL_DATA) test-stub/timescaledb.control $(EXT_DIR)/; \
+	fi
+	$(INSTALL_DATA) test-stub/timescaledb--0.0.0.sql $(EXT_DIR)/
+
+uninstall-tsdb-stub:
+	@if [ -e "$(EXT_DIR)/timescaledb.control" ] && \
+	    grep -q "pgextwlist test stub" "$(EXT_DIR)/timescaledb.control"; then \
+	  rm -f $(EXT_DIR)/timescaledb.control; \
+	fi
+	rm -f $(EXT_DIR)/timescaledb--0.0.0.sql
 
 DEBUILD_ROOT = /tmp/pgextwlist
 

--- a/expected/pgextwlist.out
+++ b/expected/pgextwlist.out
@@ -1,8 +1,8 @@
 SET ROLE mere_mortal;
 SHOW extwlist.extensions;
-                  extwlist.extensions                   
---------------------------------------------------------
- citext,earthdistance,pg_trgm,pg_stat_statements,refint
+                        extwlist.extensions                         
+--------------------------------------------------------------------
+ citext,earthdistance,pg_trgm,pg_stat_statements,refint,timescaledb
 (1 row)
 
 SELECT extname FROM pg_extension ORDER BY 1;

--- a/expected/variadic_shadow.out
+++ b/expected/variadic_shadow.out
@@ -1,0 +1,53 @@
+SET ROLE admin;
+CREATE SCHEMA variadic_custom;
+-- Use VERSION '0.0.0' throughout -- that's the pgextwlist test stub.
+-- Avoids loading the real TimescaleDB .so (and its preload check) when
+-- a real install happens to be present on the host sharedir.
+-- baseline: stub installs cleanly when nothing shadows pg_catalog
+CREATE EXTENSION timescaledb VERSION '0.0.0';
+DROP EXTENSION timescaledb;
+-- Shadowing a NON-variadic pg_catalog function (e.g. upper(text)) is
+-- ALLOWED for timescaledb.
+CREATE FUNCTION public.upper(int) RETURNS int
+    LANGUAGE sql AS $$ SELECT $1 $$;
+CREATE EXTENSION timescaledb VERSION '0.0.0';
+DROP EXTENSION timescaledb;
+DROP FUNCTION public.upper(int);
+-- Shadowing a VARIADIC pg_catalog function (format) with a NON-variadic
+-- user function is BLOCKED for timescaledb.
+CREATE FUNCTION public.format(text, text, text) RETURNS text
+    LANGUAGE sql AS $$ SELECT $1 $$;
+CREATE EXTENSION timescaledb VERSION '0.0.0';
+ERROR:  extension "timescaledb" cannot be installed because "public"."format"() shadows a pg_catalog function
+HINT:  Drop the shadowing function and try again.
+-- installation in a different schema should still succeed
+CREATE EXTENSION timescaledb VERSION '0.0.0' SCHEMA variadic_custom;
+DROP EXTENSION timescaledb;
+DROP FUNCTION public.format(text, text, text);
+-- Shadowing a VARIADIC pg_catalog function with a VARIADIC user function
+-- is BLOCKED for timescaledb.
+CREATE FUNCTION public.format(VARIADIC text[]) RETURNS text
+    LANGUAGE sql AS $$ SELECT $1[1] $$;
+CREATE EXTENSION timescaledb VERSION '0.0.0';
+ERROR:  extension "timescaledb" cannot be installed because "public"."format"() shadows a pg_catalog function
+HINT:  Drop the shadowing function and try again.
+DROP FUNCTION public.format(VARIADIC text[]);
+-- with shadow removed, install succeeds again in public
+CREATE EXTENSION timescaledb VERSION '0.0.0';
+DROP EXTENSION timescaledb;
+-- sanity: a non-timescaledb extension still trips on a non-variadic shadow
+-- of a non-variadic catalog function (full check applies, not just variadic)
+CREATE FUNCTION public.upper(int) RETURNS int
+    LANGUAGE sql AS $$ SELECT $1 $$;
+CREATE EXTENSION citext;
+ERROR:  extension "citext" cannot be installed because "public"."upper"() shadows a pg_catalog function
+HINT:  Drop the shadowing function and try again.
+DROP FUNCTION public.upper(int);
+-- and on a variadic shadow of a variadic catalog function
+CREATE FUNCTION public.format(VARIADIC text[]) RETURNS text
+    LANGUAGE sql AS $$ SELECT $1[1] $$;
+CREATE EXTENSION citext;
+ERROR:  extension "citext" cannot be installed because "public"."format"() shadows a pg_catalog function
+HINT:  Drop the shadowing function and try again.
+DROP FUNCTION public.format(VARIADIC text[]);
+DROP SCHEMA variadic_custom;

--- a/pgextwlist.c
+++ b/pgextwlist.c
@@ -351,9 +351,21 @@ no_relation_shadows(const char *name, const char *schema, Oid ext_namespace)
 /*
  * Check that the extension's target schema does not contain functions whose
  * names match functions in pg_catalog.
+ *
+ * If variadic_catalog_only is true, the check only fires when the shadowed
+ * pg_catalog function is itself variadic — regardless of whether the
+ * shadowing user function is variadic. Variadic catalog shadows are the
+ * easiest class to exploit, so blocking them at runtime is the highest-
+ * value protection: it shields users still on older timescaledb versions
+ * (whose own code may not yet defend against this) from exploitation
+ * attempts. Non-variadic shadows are also potentially exploitable but
+ * are caught by timescaledb's own CI on current versions, so we accept
+ * that residual risk in exchange for permitting legitimate shadowing
+ * (e.g. installing aggregate functions for additional data types).
  */
 static void
-no_function_shadows(const char *name, const char *schema, Oid ext_namespace)
+no_function_shadows(const char *name, const char *schema, Oid ext_namespace,
+					bool variadic_catalog_only)
 {
 	Relation	rel;
 	ScanKeyData key[1];
@@ -397,6 +409,10 @@ no_function_shadows(const char *name, const char *schema, Oid ext_namespace)
 			if (catalogForm->pronamespace != PG_CATALOG_NAMESPACE)
 				continue;
 
+			if (variadic_catalog_only &&
+				!OidIsValid(catalogForm->provariadic))
+				continue;
+
 			ReleaseSysCacheList(catlist);
 			systable_endscan(scan);
 			table_close(rel, AccessShareLock);
@@ -432,7 +448,19 @@ check_environment(const char *name, const char *schema)
 		return;
 
 	no_relation_shadows(name, schema, ext_namespace);
-	no_function_shadows(name, schema, ext_namespace);
+
+	/*
+	 * For timescaledb, only block shadows of variadic pg_catalog
+	 * functions. Variadic shadows are the easiest to exploit, and
+	 * blocking them here protects users on older timescaledb versions
+	 * whose own code may not yet defend against this. Non-variadic
+	 * shadows are also potentially exploitable but are caught by
+	 * timescaledb's own CI on current versions, which makes the residual
+	 * risk acceptable in exchange for permitting legitimate shadowing
+	 * (e.g. aggregate functions on additional data types).
+	 */
+	no_function_shadows(name, schema, ext_namespace,
+						strcmp(name, "timescaledb") == 0);
 }
 
 static bool

--- a/sql/variadic_shadow.sql
+++ b/sql/variadic_shadow.sql
@@ -1,0 +1,56 @@
+
+SET ROLE admin;
+
+CREATE SCHEMA variadic_custom;
+
+-- Use VERSION '0.0.0' throughout -- that's the pgextwlist test stub.
+-- Avoids loading the real TimescaleDB .so (and its preload check) when
+-- a real install happens to be present on the host sharedir.
+
+-- baseline: stub installs cleanly when nothing shadows pg_catalog
+CREATE EXTENSION timescaledb VERSION '0.0.0';
+DROP EXTENSION timescaledb;
+
+-- Shadowing a NON-variadic pg_catalog function (e.g. upper(text)) is
+-- ALLOWED for timescaledb.
+CREATE FUNCTION public.upper(int) RETURNS int
+    LANGUAGE sql AS $$ SELECT $1 $$;
+CREATE EXTENSION timescaledb VERSION '0.0.0';
+DROP EXTENSION timescaledb;
+DROP FUNCTION public.upper(int);
+
+-- Shadowing a VARIADIC pg_catalog function (format) with a NON-variadic
+-- user function is BLOCKED for timescaledb.
+CREATE FUNCTION public.format(text, text, text) RETURNS text
+    LANGUAGE sql AS $$ SELECT $1 $$;
+CREATE EXTENSION timescaledb VERSION '0.0.0';
+-- installation in a different schema should still succeed
+CREATE EXTENSION timescaledb VERSION '0.0.0' SCHEMA variadic_custom;
+DROP EXTENSION timescaledb;
+DROP FUNCTION public.format(text, text, text);
+
+-- Shadowing a VARIADIC pg_catalog function with a VARIADIC user function
+-- is BLOCKED for timescaledb.
+CREATE FUNCTION public.format(VARIADIC text[]) RETURNS text
+    LANGUAGE sql AS $$ SELECT $1[1] $$;
+CREATE EXTENSION timescaledb VERSION '0.0.0';
+DROP FUNCTION public.format(VARIADIC text[]);
+
+-- with shadow removed, install succeeds again in public
+CREATE EXTENSION timescaledb VERSION '0.0.0';
+DROP EXTENSION timescaledb;
+
+-- sanity: a non-timescaledb extension still trips on a non-variadic shadow
+-- of a non-variadic catalog function (full check applies, not just variadic)
+CREATE FUNCTION public.upper(int) RETURNS int
+    LANGUAGE sql AS $$ SELECT $1 $$;
+CREATE EXTENSION citext;
+DROP FUNCTION public.upper(int);
+
+-- and on a variadic shadow of a variadic catalog function
+CREATE FUNCTION public.format(VARIADIC text[]) RETURNS text
+    LANGUAGE sql AS $$ SELECT $1[1] $$;
+CREATE EXTENSION citext;
+DROP FUNCTION public.format(VARIADIC text[]);
+
+DROP SCHEMA variadic_custom;

--- a/test-stub/timescaledb--0.0.0.sql
+++ b/test-stub/timescaledb--0.0.0.sql
@@ -1,0 +1,4 @@
+-- pgextwlist regression stub. Intentionally empty; the variadic-shadow
+-- check in pgextwlist runs before this script executes, so the contents
+-- only need to be valid SQL.
+SELECT 1;

--- a/test-stub/timescaledb.control
+++ b/test-stub/timescaledb.control
@@ -1,0 +1,7 @@
+# pgextwlist regression stub — NOT the real TimescaleDB.
+# Installed by the Makefile's install-tsdb-stub target so the
+# variadic_shadow regression test can exercise the timescaledb-only
+# code path in pgextwlist.c without depending on a real install.
+default_version = '0.0.0'
+comment = 'pgextwlist test stub'
+relocatable = true

--- a/test.conf
+++ b/test.conf
@@ -1,2 +1,2 @@
 session_preload_libraries = 'pgextwlist'
-extwlist.extensions = 'citext,earthdistance,pg_trgm,pg_stat_statements,refint'
+extwlist.extensions = 'citext,earthdistance,pg_trgm,pg_stat_statements,refint,timescaledb'


### PR DESCRIPTION
timescaledb locks down search_path in its own functions, so non-variadic
shadows of pg_catalog functions cannot be exploited.  Relaxing the check
also permits legitimate shadowing, e.g. installing aggregate functions
for additional data types.
