### PR TITLE
Block CREATE EXTENSION into a precreated non-superuser-owned pinned schema

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ long_ver = $(shell (git describe --tags --long '--match=v*' 2>/dev/null || echo 
 MODULE_big = pgextwlist
 OBJS       = utils.o pgextwlist.o
 DOCS       = README.md
-REGRESS    = setup pgextwlist errors crossuser hooks pg_temp catalog_shadow variadic_shadow alter_update_shadow
+REGRESS    = setup pgextwlist errors crossuser hooks pg_temp catalog_shadow variadic_shadow alter_update_shadow pinned_schema
 REGRESS_OPTS += --temp-instance=./tmp_check --temp-config=test.conf
 RPM_MINOR_VERSION_SUFFIX ?=
 
@@ -22,6 +22,9 @@ include $(PGXS)
 # add our --0.0.0.sql alongside its many version files. The regression
 # test uses CREATE EXTENSION timescaledb VERSION '0.0.0' so the real
 # .so is never loaded and the preload check is skipped.
+#
+# The same target also installs the "pinned_stub" extension, whose control
+# file pins its schema, used by the pinned_schema regression test.
 EXT_DIR := $(shell $(PG_CONFIG) --sharedir)/extension
 
 .PHONY: install-tsdb-stub uninstall-tsdb-stub
@@ -35,6 +38,7 @@ install-tsdb-stub:
 	$(INSTALL_DATA) test-stub/timescaledb--0.0.0.sql $(EXT_DIR)/
 	$(INSTALL_DATA) test-stub/timescaledb--0.0.1.sql $(EXT_DIR)/
 	$(INSTALL_DATA) test-stub/timescaledb--0.0.0--0.0.1.sql $(EXT_DIR)/
+	$(INSTALL_DATA) test-stub/pinned_stub.control test-stub/pinned_stub--*.sql $(EXT_DIR)/
 
 uninstall-tsdb-stub:
 	@if [ -e "$(EXT_DIR)/timescaledb.control" ] && \
@@ -44,6 +48,7 @@ uninstall-tsdb-stub:
 	rm -f $(EXT_DIR)/timescaledb--0.0.0.sql
 	rm -f $(EXT_DIR)/timescaledb--0.0.1.sql
 	rm -f $(EXT_DIR)/timescaledb--0.0.0--0.0.1.sql
+	rm -f $(EXT_DIR)/pinned_stub.control $(EXT_DIR)/pinned_stub--*.sql
 
 DEBUILD_ROOT = /tmp/pgextwlist
 

--- a/expected/pgextwlist.out
+++ b/expected/pgextwlist.out
@@ -1,8 +1,8 @@
 SET ROLE mere_mortal;
 SHOW extwlist.extensions;
-                        extwlist.extensions                         
---------------------------------------------------------------------
- citext,earthdistance,pg_trgm,pg_stat_statements,refint,timescaledb
+                              extwlist.extensions                               
+--------------------------------------------------------------------------------
+ citext,earthdistance,pg_trgm,pg_stat_statements,refint,timescaledb,pinned_stub
 (1 row)
 
 SELECT extname FROM pg_extension ORDER BY 1;

--- a/expected/pinned_schema.out
+++ b/expected/pinned_schema.out
@@ -1,0 +1,66 @@
+SET ROLE admin;
+-- pinned_stub pins "schema = pinned_stub" in its control file. A
+-- precreated pinned schema must be owned by a superuser, otherwise
+-- CREATE EXTENSION and ALTER EXTENSION UPDATE are blocked.
+-- fresh install: the schema does not exist and is created during
+-- CREATE EXTENSION, owned by the bootstrap superuser.
+CREATE EXTENSION pinned_stub;
+SELECT r.rolsuper AS schema_owner_is_superuser
+  FROM pg_namespace n JOIN pg_roles r ON r.oid = n.nspowner
+ WHERE n.nspname = 'pinned_stub';
+ schema_owner_is_superuser 
+---------------------------
+ t
+(1 row)
+
+DROP EXTENSION pinned_stub;
+-- DROP EXTENSION leaves the schema behind, superuser-owned;
+-- reinstalling into it succeeds.
+CREATE EXTENSION pinned_stub;
+DROP EXTENSION pinned_stub;
+RESET ROLE;
+DROP SCHEMA pinned_stub;
+SET ROLE admin;
+-- a precreated schema owned by a non-superuser blocks installation.
+CREATE SCHEMA pinned_stub;
+CREATE EXTENSION pinned_stub;
+ERROR:  extension "pinned_stub" cannot be installed into schema "pinned_stub" because the schema is not owned by a superuser
+HINT:  Drop the schema so it can be created during installation.
+-- an explicit SCHEMA clause naming the pinned schema is blocked the same way.
+CREATE EXTENSION pinned_stub SCHEMA pinned_stub;
+ERROR:  extension "pinned_stub" cannot be installed into schema "pinned_stub" because the schema is not owned by a superuser
+HINT:  Drop the schema so it can be created during installation.
+DROP SCHEMA pinned_stub;
+-- an explicit SCHEMA clause that does not match the pinned schema is
+-- rejected by core, not by the ownership check.
+CREATE SCHEMA not_pinned;
+CREATE EXTENSION pinned_stub SCHEMA not_pinned;
+ERROR:  extension "pinned_stub" must be installed in schema "pinned_stub"
+DROP SCHEMA not_pinned;
+-- the ownership requirement is scoped to extensions that pin their schema.
+-- timescaledb does not pin one, so it may be installed into a schema owned
+-- by a non-superuser (the admin role); the shadow checks still apply.
+CREATE SCHEMA unpinned_target;
+CREATE EXTENSION timescaledb VERSION '0.0.0' SCHEMA unpinned_target;
+DROP EXTENSION timescaledb;
+DROP SCHEMA unpinned_target;
+-- a precreated superuser-owned schema is usable.
+RESET ROLE;
+CREATE SCHEMA pinned_stub;
+SET ROLE admin;
+CREATE EXTENSION pinned_stub VERSION '0.0.0';
+-- ALTER EXTENSION UPDATE is blocked when the schema is not superuser-owned.
+RESET ROLE;
+ALTER SCHEMA pinned_stub OWNER TO mere_mortal;
+SET ROLE admin;
+ALTER EXTENSION pinned_stub UPDATE TO '0.0.1';
+ERROR:  extension "pinned_stub" cannot be installed into schema "pinned_stub" because the schema is not owned by a superuser
+HINT:  Drop the schema so it can be created during installation.
+-- with the schema back under superuser ownership, the update succeeds.
+RESET ROLE;
+ALTER SCHEMA pinned_stub OWNER TO CURRENT_USER;
+SET ROLE admin;
+ALTER EXTENSION pinned_stub UPDATE TO '0.0.1';
+DROP EXTENSION pinned_stub;
+RESET ROLE;
+DROP SCHEMA pinned_stub;

--- a/pgextwlist.c
+++ b/pgextwlist.c
@@ -307,6 +307,49 @@ pg_temp_is_empty(const char *name)
 }
 
 /*
+ * When the extension's control file pins its schema ("schema = ..."), the
+ * schema is dedicated to the extension and the legitimate install flow is
+ * that CREATE EXTENSION creates it -- which here happens as the bootstrap
+ * superuser, yielding a superuser-owned schema with no grants.
+ *
+ * A pre-existing schema owned by a non-superuser is a security risk because
+ * the extension scripts run as superuser and can resolve objects from that
+ * schema. To prevent this we require the pinned schema to be either absent
+ * or superuser-owned.
+ */
+static void
+pinned_schema_is_superuser_owned(const char *name, const char *schema,
+								 Oid ext_namespace)
+{
+	char	   *control_schema;
+	HeapTuple	tup;
+	Oid			owner;
+
+	control_schema = get_extension_control_schema(name);
+
+	/*
+	 * A target schema different from the pinned one is rejected by core, no
+	 * need to check anything here.
+	 */
+	if (control_schema == NULL || strcmp(control_schema, schema) != 0)
+		return;
+
+	tup = SearchSysCache1(NAMESPACEOID, ObjectIdGetDatum(ext_namespace));
+	if (!HeapTupleIsValid(tup))
+		elog(ERROR, "cache lookup failed for namespace %u", ext_namespace);
+	owner = ((Form_pg_namespace) GETSTRUCT(tup))->nspowner;
+	ReleaseSysCache(tup);
+
+	if (!superuser_arg(owner))
+		ereport(ERROR,
+				(errcode(ERRCODE_OPERATOR_INTERVENTION),
+				 errmsg("extension \"%s\" cannot be installed into schema \"%s\" "
+						"because the schema is not owned by a superuser",
+						name, schema),
+				 errhint("Drop the schema so it can be created during installation.")));
+}
+
+/*
  * Check that the extension's target schema does not contain relations whose
  * names match relations in pg_catalog.
  */
@@ -444,13 +487,15 @@ check_environment(const char *name, const char *schema)
 
 	pg_temp_is_empty(name);
 
-	ext_namespace = LookupExplicitNamespace(schema, true);
+	ext_namespace = get_namespace_oid(schema, true);
 	if (!OidIsValid(ext_namespace))
 		return;
 
 	/* If the extension targets pg_catalog itself, no shadowing is possible */
 	if (ext_namespace == PG_CATALOG_NAMESPACE)
 		return;
+
+	pinned_schema_is_superuser_owned(name, schema, ext_namespace);
 
 	no_relation_shadows(name, schema, ext_namespace);
 

--- a/sql/pinned_schema.sql
+++ b/sql/pinned_schema.sql
@@ -1,0 +1,67 @@
+
+SET ROLE admin;
+
+-- pinned_stub pins "schema = pinned_stub" in its control file. A
+-- precreated pinned schema must be owned by a superuser, otherwise
+-- CREATE EXTENSION and ALTER EXTENSION UPDATE are blocked.
+
+-- fresh install: the schema does not exist and is created during
+-- CREATE EXTENSION, owned by the bootstrap superuser.
+CREATE EXTENSION pinned_stub;
+SELECT r.rolsuper AS schema_owner_is_superuser
+  FROM pg_namespace n JOIN pg_roles r ON r.oid = n.nspowner
+ WHERE n.nspname = 'pinned_stub';
+DROP EXTENSION pinned_stub;
+
+-- DROP EXTENSION leaves the schema behind, superuser-owned;
+-- reinstalling into it succeeds.
+CREATE EXTENSION pinned_stub;
+DROP EXTENSION pinned_stub;
+
+RESET ROLE;
+DROP SCHEMA pinned_stub;
+SET ROLE admin;
+
+-- a precreated schema owned by a non-superuser blocks installation.
+CREATE SCHEMA pinned_stub;
+CREATE EXTENSION pinned_stub;
+
+-- an explicit SCHEMA clause naming the pinned schema is blocked the same way.
+CREATE EXTENSION pinned_stub SCHEMA pinned_stub;
+DROP SCHEMA pinned_stub;
+
+-- an explicit SCHEMA clause that does not match the pinned schema is
+-- rejected by core, not by the ownership check.
+CREATE SCHEMA not_pinned;
+CREATE EXTENSION pinned_stub SCHEMA not_pinned;
+DROP SCHEMA not_pinned;
+
+-- the ownership requirement is scoped to extensions that pin their schema.
+-- timescaledb does not pin one, so it may be installed into a schema owned
+-- by a non-superuser (the admin role); the shadow checks still apply.
+CREATE SCHEMA unpinned_target;
+CREATE EXTENSION timescaledb VERSION '0.0.0' SCHEMA unpinned_target;
+DROP EXTENSION timescaledb;
+DROP SCHEMA unpinned_target;
+
+-- a precreated superuser-owned schema is usable.
+RESET ROLE;
+CREATE SCHEMA pinned_stub;
+SET ROLE admin;
+CREATE EXTENSION pinned_stub VERSION '0.0.0';
+
+-- ALTER EXTENSION UPDATE is blocked when the schema is not superuser-owned.
+RESET ROLE;
+ALTER SCHEMA pinned_stub OWNER TO mere_mortal;
+SET ROLE admin;
+ALTER EXTENSION pinned_stub UPDATE TO '0.0.1';
+
+-- with the schema back under superuser ownership, the update succeeds.
+RESET ROLE;
+ALTER SCHEMA pinned_stub OWNER TO CURRENT_USER;
+SET ROLE admin;
+ALTER EXTENSION pinned_stub UPDATE TO '0.0.1';
+DROP EXTENSION pinned_stub;
+
+RESET ROLE;
+DROP SCHEMA pinned_stub;

--- a/test-stub/pinned_stub--0.0.0--0.0.1.sql
+++ b/test-stub/pinned_stub--0.0.0--0.0.1.sql
@@ -1,0 +1,4 @@
+-- pgextwlist regression stub. Intentionally empty; the pinned-schema
+-- ownership check in pgextwlist runs before this script executes, so the
+-- contents only need to be valid SQL.
+SELECT 1;

--- a/test-stub/pinned_stub--0.0.0.sql
+++ b/test-stub/pinned_stub--0.0.0.sql
@@ -1,0 +1,4 @@
+-- pgextwlist regression stub. Intentionally empty; the pinned-schema
+-- ownership check in pgextwlist runs before this script executes, so the
+-- contents only need to be valid SQL.
+SELECT 1;

--- a/test-stub/pinned_stub.control
+++ b/test-stub/pinned_stub.control
@@ -1,0 +1,8 @@
+# pgextwlist regression stub — NOT a real extension.
+# Installed by the Makefile's install-tsdb-stub target so the
+# pinned_schema regression test can exercise the control-file-pinned
+# schema ownership check in pgextwlist.c.
+default_version = '0.0.0'
+comment = 'pgextwlist test stub'
+relocatable = false
+schema = 'pinned_stub'

--- a/test.conf
+++ b/test.conf
@@ -1,2 +1,2 @@
 session_preload_libraries = 'pgextwlist'
-extwlist.extensions = 'citext,earthdistance,pg_trgm,pg_stat_statements,refint,timescaledb'
+extwlist.extensions = 'citext,earthdistance,pg_trgm,pg_stat_statements,refint,timescaledb,pinned_stub'

--- a/utils.c
+++ b/utils.c
@@ -126,6 +126,21 @@ parse_default_version_in_control_file(const char *extname,
 }
 
 /*
+ * Return the schema pinned by the extension's control file ("schema = ..."),
+ * or NULL when the control file does not specify one.
+ */
+char *
+get_extension_control_schema(const char *extname)
+{
+	char	   *version = NULL;
+	char	   *schema = NULL;
+
+	parse_default_version_in_control_file(extname, &version, &schema);
+
+	return schema;
+}
+
+/*
  * We lookup scripts at the following places and run them when they exist:
  *
  *  ${extwlist_custom_path}/${extname}/${when}--${version}.sql (upgrade)

--- a/utils.h
+++ b/utils.h
@@ -31,6 +31,8 @@ char *get_generic_custom_script_filename(const char *name,
 
 char *get_extension_current_version(const char *extname);
 
+char *get_extension_control_schema(const char *extname);
+
 void fill_in_extension_properties(const char *extname,
 								  List *options,
 								  char **schema,


### PR DESCRIPTION
When an extension's control file pins its schema ("schema = ..."), the
schema is dedicated to the extension and the legitimate install flow has
CREATE EXTENSION create it -- which under pgextwlist happens as the
bootstrap superuser, yielding a superuser-owned schema. A pre-existing
pinned schema owned by a non-superuser is can be user to escalate
privileges as it will be in the search_path and objects from it may be
resolved by the extension upgrade script.
